### PR TITLE
Short delay between each key press

### DIFF
--- a/Network Remote.pyw
+++ b/Network Remote.pyw
@@ -369,6 +369,7 @@ def kbsend(*codes):
     """ Expand a KEYBOARD command sequence for send(). """
     for each in codes:
         send('KEYBOARD %s\r' % each)
+        time.sleep(0.1)
 
 def closed_caption(widget=None):
     """ Toggle closed captioning. """


### PR DESCRIPTION
Add a short delay between each key press. This fixes an issue on the TiVo Mini where some characters were not being recognized.